### PR TITLE
Adds androidlog C-Python extensions to repy_v2 sandbox

### DIFF
--- a/namespace.py
+++ b/namespace.py
@@ -949,11 +949,27 @@ if IS_ANDROID:
 	    'return': NoneOrListOrDict()}
   }
 
+  SNAKEI_OUTPUTS_WRAPPER_INFO = {
+      'log': {
+      'func': androidlog.log,
+      'args': [Str()],
+      'return': None},
+      'toast': {
+      'func': androidlog.toast,
+      'args': [Str()],
+      'return': None},
+      'prompt': {
+      'func': androidlog.prompt,
+      'args': [Str()],
+      'return': Bool()}
+  }
+
   # Add sensor calls to the user namespace
   USERCONTEXT_WRAPPER_INFO.update(SNAKEI_SENSOR_WRAPPER_INFO)
   USERCONTEXT_WRAPPER_INFO.update(SNAKEI_MISCINFO_WRAPPER_INFO)
   USERCONTEXT_WRAPPER_INFO.update(SNAKEI_MEDIA_WRAPPER_INFO)
   USERCONTEXT_WRAPPER_INFO.update(SNAKEI_LOCATION_WRAPPER_INFO)
+  USERCONTEXT_WRAPPER_INFO.update(SNAKEI_OUTPUTS_WRAPPER_INFO)
 
 
 ##############################################################################

--- a/namespace.py
+++ b/namespace.py
@@ -778,187 +778,187 @@ VIRTUAL_NAMESPACE_OBJECT_WRAPPER_INFO = {
 # On Android, define wrappers for sensor calls exposed through JNI.
 if IS_ANDROID:
   SNAKEI_MISCINFO_WRAPPER_INFO = {
-      'get_bluetooth_info': {
-	'func': miscinfo.get_bluetooth_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_bluetooth_scan_info': {
-	'func': miscinfo.get_bluetooth_scan_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'is_wifi_enabled': {
-	'func': miscinfo.is_wifi_enabled,
-	'args': [],
-	'return': Bool()},
-      'get_wifi_state': {
-	'func': miscinfo.get_wifi_state,
-	'args': [],
-	'return': Int()},
-      'get_wifi_connection_info': {
-	'func': miscinfo.get_wifi_connection_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_wifi_scan_info': {
-	'func': miscinfo.get_wifi_scan_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_network_info': {
-	'func': miscinfo.get_network_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_cellular_provider_info': {
-	'func': miscinfo.get_cellular_provider_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_cell_info': {
-	'func': miscinfo.get_cell_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_sim_info': {
-	'func': miscinfo.get_sim_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_phone_info': {
-	'func': miscinfo.get_phone_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_mode_settings': {
-	'func': miscinfo.get_mode_settings,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_display_info': {
-	'func': miscinfo.get_display_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_volume_info': {
-	'func': miscinfo.get_volume_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
-      'get_battery_info': {
-	'func': miscinfo.get_battery_info,
-	'args': [],
-	'return': NoneOrListOrDict()},
+    'get_bluetooth_info': {
+      'func': miscinfo.get_bluetooth_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_bluetooth_scan_info': {
+      'func': miscinfo.get_bluetooth_scan_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'is_wifi_enabled': {
+      'func': miscinfo.is_wifi_enabled,
+      'args': [],
+      'return': Bool()},
+    'get_wifi_state': {
+      'func': miscinfo.get_wifi_state,
+      'args': [],
+      'return': Int()},
+    'get_wifi_connection_info': {
+      'func': miscinfo.get_wifi_connection_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_wifi_scan_info': {
+      'func': miscinfo.get_wifi_scan_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_network_info': {
+      'func': miscinfo.get_network_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_cellular_provider_info': {
+      'func': miscinfo.get_cellular_provider_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_cell_info': {
+      'func': miscinfo.get_cell_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_sim_info': {
+      'func': miscinfo.get_sim_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_phone_info': {
+      'func': miscinfo.get_phone_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_mode_settings': {
+      'func': miscinfo.get_mode_settings,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_display_info': {
+      'func': miscinfo.get_display_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_volume_info': {
+      'func': miscinfo.get_volume_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
+    'get_battery_info': {
+      'func': miscinfo.get_battery_info,
+      'args': [],
+      'return': NoneOrListOrDict()},
   }
 
   SNAKEI_SENSOR_WRAPPER_INFO = {
-      'get_sensor_list': {
+    'get_sensor_list': {
 	    'func': sensor.get_sensor_list,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_acceleration': {
+    'get_acceleration': {
 	    'func': sensor.get_acceleration,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_ambient_temperature': {
+    'get_ambient_temperature': {
 	    'func': sensor.get_ambient_temperature,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_game_rotation_vector': {
+    'get_game_rotation_vector': {
 	    'func': sensor.get_game_rotation_vector,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_geomagnetic_rotation_vector': {
+    'get_geomagnetic_rotation_vector': {
 	    'func': sensor.get_geomagnetic_rotation_vector,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_gravity': {
+    'get_gravity': {
 	    'func': sensor.get_gravity,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_gyroscope': {
+    'get_gyroscope': {
 	    'func': sensor.get_gyroscope,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_gyroscope_uncalibrated': {
+    'get_gyroscope_uncalibrated': {
 	    'func': sensor.get_gyroscope_uncalibrated,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_heart_rate': {
+    'get_heart_rate': {
 	    'func': sensor.get_heart_rate,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_light': {
+    'get_light': {
 	    'func': sensor.get_light,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_linear_acceleration': {
+    'get_linear_acceleration': {
 	    'func': sensor.get_linear_acceleration,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_magnetic_field': {
+    'get_magnetic_field': {
 	    'func': sensor.get_magnetic_field,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_magnetic_field_uncalibrated': {
+    'get_magnetic_field_uncalibrated': {
 	    'func': sensor.get_magnetic_field_uncalibrated,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_pressure': {
+    'get_pressure': {
 	    'func': sensor.get_pressure,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_proximity': {
+    'get_proximity': {
 	    'func': sensor.get_proximity,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_relative_humidity': {
+    'get_relative_humidity': {
 	    'func': sensor.get_relative_humidity,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_rotation_vector': {
+    'get_rotation_vector': {
 	    'func': sensor.get_rotation_vector,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_step_counter': {
+    'get_step_counter': {
 	    'func': sensor.get_step_counter,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
   }
 
   SNAKEI_MEDIA_WRAPPER_INFO = {
-      'microphone_record': {
+    'microphone_record': {
 	    'func': media.microphone_record,
 	    'args': [Str(maxlen=120), Int(min=0)],
 	    'return': None},
-      'is_media_playing': {
+    'is_media_playing': {
 	    'func': media.is_media_playing,
 	    'args': [],
 	    'return': Bool()},
-      'is_tts_speaking': {
+    'is_tts_speaking': {
 	    'func': media.is_tts_speaking,
 	    'args': [],
 	    'return': Bool()},
-      'tts_speak': {
+    'tts_speak': {
 	    'func': media.tts_speak,
 	    'args': [Str(maxlen=1024)],
 	    'return': None}
   }
 
   SNAKEI_LOCATION_WRAPPER_INFO = {
-      'get_location': {
+    'get_location': {
 	    'func': location.get_location,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_lastknown_location': {
+    'get_lastknown_location': {
 	    'func': location.get_lastknown_location,
 	    'args': [],
 	    'return': NoneOrListOrDict()},
-      'get_geolocation': {
+    'get_geolocation': {
 	    'func': location.get_geolocation,
 	    'args': [Float(True), Float(True), Int()],
 	    'return': NoneOrListOrDict()}
   }
 
   SNAKEI_OUTPUTS_WRAPPER_INFO = {
-      'log': {
+    'log': {
       'func': androidlog.log,
       'args': [Str()],
       'return': None},
-      'toast': {
+    'toast': {
       'func': androidlog.toast,
       'args': [Str()],
       'return': None},
-      'prompt': {
+    'prompt': {
       'func': androidlog.prompt,
       'args': [Str()],
       'return': Bool()}


### PR DESCRIPTION
log - write message to android log
toast - write message to android UI
prompt - write message to android UI, wait for boolean user input

I suggest we only provide `toast` and `prompt` to experimenters that are also the device donors.
