### PR TITLE
Adds androidlog.notify C-Python extensions to repy

### DIFF
--- a/namespace.py
+++ b/namespace.py
@@ -972,6 +972,10 @@ if IS_ANDROID:
       'func': androidlog.toast,
       'args': [Str()],
       'return': None},
+    'notify': {
+      'func': androidlog.notify,
+      'args': [Str()],
+      'return': None},
     'prompt': {
       'func': androidlog.prompt,
       'args': [Str()],


### PR DESCRIPTION
Similar to androidlog.toast the repy sandbox can now send messages to the system notification drawer. And that's about it. A user can only look at the notification and/or dismiss it, but there is not other interaction than that.
